### PR TITLE
Fixes warnings/errors for 32-bit (and maybe ILP64?) builds

### DIFF
--- a/containers.cpp
+++ b/containers.cpp
@@ -79,7 +79,8 @@ packToken TokenList::default_constructor(TokenMap scope) {
 
 packToken* TokenList::ListIterator::next() {
   if (i < list->size()) {
-    return &list->at(i++);
+    TokenList_t::size_type idx = TokenList_t::size_type(i++);
+    return &list->at(idx);
   } else {
     i = 0;
     return NULL;

--- a/containers.h
+++ b/containers.h
@@ -166,7 +166,8 @@ struct TokenList : public Container<TokenList_t>, public Iterable {
     if (list().size() <= idx) {
       throw std::out_of_range("List index out of range!");
     }
-    return list()[idx];
+    TokenList_t::size_type i = TokenList_t::size_type(idx);
+    return list()[i];
   }
 
   void push(packToken val) const { list().push_back(val); }


### PR DESCRIPTION
BugFix: ARM32, and possibly other archs, fails with -Werror

The code implicitly casts a uint64_t to a vector::size_type. It does so only after checking bounds (against a value that must have come from a size_type, and without using signed types anywhere), so it should be safe, but it still causes warnings.